### PR TITLE
Code simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # vscode
 .vscode
+
+.idea/

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -56,11 +56,11 @@ print(list_of_namespaces)
 ```python
 
 # Get project by registry
-pr_ob = projectDB.get_project_by_registry(registry_path='Test/subtable3')
+pr_ob = projectDB.get_project_by_registry_path(registry_path='Test/subtable3')
 print(pr_ob.samples)
 
 # Get project by registry
-pr_ob = projectDB.get_project_by_registry(registry_path='Test/subtable3:this_is_tag')
+pr_ob = projectDB.get_project_by_registry_path(registry_path='Test/subtable3:this_is_tag')
 print(pr_ob.samples)
 
 # Get project by namespace and name
@@ -103,14 +103,14 @@ print(pr_ob.samples)
 ```python
 
 # Get dictionary of annotation for 1 project by registry
-projects_anno_list = projectDB.get_project_annotation_by_registry(registry='Test/subtable3:this_is_tag')
+projects_anno_list = projectDB.get_project_annotation_by_registry_path()
 # if tag is not set default tag will be set
 projects_anno_list = projectDB.get_project_annotation(namespace='Test/subtable3')
 
 # As a return value user will get `Annotation` class object. There is two options to retrieve data:
-#1) Using object as simple dict:
+# 1) Using object as simple dict:
 projects_anno_list["status"]
-#2) Using .key ; Available keys:
+# 2) Using .key ; Available keys:
 projects_anno_list.registry  # to know what project annotation is it 
 projects_anno_list.status
 projects_anno_list.description
@@ -140,7 +140,7 @@ projectDB.project_exists(namespace="nn", name="buu")
 projectDB.project_exists(namespace="nn", name="buu", tag='dog')
 
 # by registry path:
-projectDB.project_exists_by_registry(registry_path='nn/buu/dog')
+projectDB.project_exists_by_registry_path(registry_path='nn/buu/dog')
 
 ```
 

--- a/pepdbagent/const.py
+++ b/pepdbagent/const.py
@@ -16,6 +16,7 @@ STATUS_KEY = "status"
 DESCRIPTION_KEY = "description"
 N_SAMPLES_KEY = "n_samples"
 UPDATE_DATE_KEY = "last_update"
+IS_PRIVATE_KEY = "is_private"
 DEFAULT_STATUS = "Unknown"
 
 BASE_ANNOTATION_DICT = {

--- a/pepdbagent/pepannot.py
+++ b/pepdbagent/pepannot.py
@@ -5,6 +5,7 @@ from .const import (
     UPDATE_DATE_KEY,
     BASE_ANNOTATION_DICT,
     DEFAULT_STATUS,
+    IS_PRIVATE_KEY,
 )
 import json
 import logmuse
@@ -62,6 +63,7 @@ class Annotation(dict):
         n_samples: int = None,
         description: str = None,
         anno_dict: dict = None,
+        is_private: bool = False,
     ):
         """
         Create a new annotation for pep-db
@@ -70,9 +72,11 @@ class Annotation(dict):
         :param n_samples: number of samples in pep
         :param description: description of PEP
         :param anno_dict: other
+        :param is_private: whether the project should be visible just for user that created it
         :return: Annotation class
         """
         new_dict = BASE_ANNOTATION_DICT
+        new_dict[IS_PRIVATE_KEY] = is_private
         if status:
             new_dict[STATUS_KEY] = status
         else:

--- a/pepdbagent/pepannot.py
+++ b/pepdbagent/pepannot.py
@@ -21,10 +21,18 @@ coloredlogs.install(
 
 class Annotation(dict):
     """
-    A class to model an annotations used in pep-db
+    A class to model an annotations used in pep-db.
+    Annotation is additional information about each project that is stored in annotation column.
+    This class will create standard annotation dictionary,
+    that can be easy retrievable, and handles lack of annotation and other errors
     """
 
     def __init__(self, annotation_dict: dict = None, registry: str = None):
+        """
+        Initialization of the annotation class
+        :param annotation_dict: Annotation dictionary, that was already created
+        :param registry: Registry path of the project
+        """
 
         super(Annotation, self).__init__()
         if annotation_dict is None:

--- a/pepdbagent/pepdbagent.py
+++ b/pepdbagent/pepdbagent.py
@@ -513,46 +513,6 @@ class Connection:
 
         return self.get_project_annotation(namespace=namespace, name=name, tag=tag)
 
-    def get_namespace_annotation(self, namespace: str = None) -> dict:
-        """
-        Retrieving namespace annotation dict.
-        Data that will be retrieved: number of tags, projects and samples
-        If namespace is None it will retrieve dict with all namespace annotations.
-        :param namespace: project namespace
-        """
-        sql_q = f"""
-        select {NAMESPACE_COL}, count(DISTINCT {TAG_COL}) as n_tags , 
-        count({NAME_COL}) as 
-        n_namespace, SUM(({ANNO_COL} ->> 'n_samples')::int) 
-        as n_samples 
-            from {DB_TABLE_NAME}
-                group by {NAMESPACE_COL};
-        """
-        result = self._run_sql_fetchall(sql_q)
-        anno_dict = {}
-
-        for name_sp_result in result:
-            anno_dict[name_sp_result[0]] = {
-                "namespace": name_sp_result[0],
-                "n_tags": name_sp_result[1],
-                "n_projects": name_sp_result[2],
-                "n_samples": name_sp_result[3],
-            }
-
-        if namespace:
-            try:
-                return anno_dict[namespace]
-            except KeyError:
-                _LOGGER.warning(f"Namespace '{namespace}' was not found.")
-                return {
-                    "namespace": namespace,
-                    "n_tags": 0,
-                    "n_projects": 0,
-                    "n_samples": 0,
-                }
-
-        return anno_dict
-
     def project_exists(
         self,
         namespace: str = None,

--- a/pepdbagent/pepdbagent.py
+++ b/pepdbagent/pepdbagent.py
@@ -513,6 +513,46 @@ class Connection:
 
         return self.get_project_annotation(namespace=namespace, name=name, tag=tag)
 
+    def get_namespace_annotation(self, namespace: str = None) -> dict:
+        """
+        Retrieving namespace annotation dict.
+        Data that will be retrieved: number of tags, projects and samples
+        If namespace is None it will retrieve dict with all namespace annotations.
+        :param namespace: project namespace
+        """
+        sql_q = f"""
+        select {NAMESPACE_COL}, count(DISTINCT {TAG_COL}) as n_tags , 
+        count({NAME_COL}) as 
+        n_namespace, SUM(({ANNO_COL} ->> 'n_samples')::int) 
+        as n_samples 
+            from {DB_TABLE_NAME}
+                group by {NAMESPACE_COL};
+        """
+        result = self._run_sql_fetchall(sql_q)
+        anno_dict = {}
+
+        for name_sp_result in result:
+            anno_dict[name_sp_result[0]] = {
+                "namespace": name_sp_result[0],
+                "n_tags": name_sp_result[1],
+                "n_projects": name_sp_result[2],
+                "n_samples": name_sp_result[3],
+            }
+
+        if namespace:
+            try:
+                return anno_dict[namespace]
+            except KeyError:
+                _LOGGER.warning(f"Namespace '{namespace}' was not found.")
+                return {
+                    "namespace": namespace,
+                    "n_tags": 0,
+                    "n_projects": 0,
+                    "n_samples": 0,
+                }
+
+        return anno_dict
+
     def project_exists(
         self,
         namespace: str = None,

--- a/pepdbagent/pepdbagent.py
+++ b/pepdbagent/pepdbagent.py
@@ -288,7 +288,7 @@ class Connection:
 
         if name is not None:
             sql_q = f""" {sql_q} where {NAME_COL}=%s and {NAMESPACE_COL}=%s and {TAG_COL}=%s;"""
-            found_prj = self.run_sql_fetchone(sql_q, name, namespace, tag)
+            found_prj = self._run_sql_fetchone(sql_q, name, namespace, tag)
 
         else:
             _LOGGER.error(
@@ -341,13 +341,13 @@ class Connection:
                     f"where namespace = %s and tag = %s "
                     f"limit {limit} offset {offset_number}"
                 )
-                results = self.run_sql_fetchall(sql_q, namespace, tag)
+                results = self._run_sql_fetchall(sql_q, namespace, tag)
             else:
                 sql_q = (
                     f"select {ID_COL}, {PROJ_COL} from {DB_TABLE_NAME} where namespace = %s"
                     f" limit {limit} offset {offset_number}"
                 )
-                results = self.run_sql_fetchall(sql_q, namespace)
+                results = self._run_sql_fetchall(sql_q, namespace)
 
         # if only tag is provided
         elif tag:
@@ -355,7 +355,7 @@ class Connection:
                 f"select {ID_COL}, {PROJ_COL} from {DB_TABLE_NAME} where tag = %s"
                 f" limit {limit} offset {offset_number}"
             )
-            results = self.run_sql_fetchall(sql_q, tag)
+            results = self._run_sql_fetchall(sql_q, tag)
             print(results)
 
         else:
@@ -374,71 +374,6 @@ class Connection:
 
         return result_list
 
-    def get_projects_in_list(
-        self,
-        registry_paths: list,
-    ) -> List[peppy.Project]:
-        """
-        Get a list of projects as peppy.Project instances.
-        Get a list of projects in a list of registry_paths
-        :registry_paths: list with registry paths of the projects
-        :return: a list of peppy.Project instances for the requested projects.
-        """
-        if not isinstance(registry_paths, list):
-            raise TypeError(f"incorrect variable type provided")
-        for rpath in registry_paths:
-            if not is_valid_resgistry_path(rpath):
-                # should we raise an error or just warn with the logger?
-                raise ValueError(f"Invalid registry path supplied: '{rpath}'")
-
-        parametrized_filter = ""
-        for i in range(len(registry_paths)):
-            parametrized_filter += "(namespace=%s and name=%s)"
-            if i < len(registry_paths) - 1:
-                parametrized_filter += " or "
-
-        sql_q = f"select {NAME_COL}, {PROJ_COL} from {DB_TABLE_NAME} where {parametrized_filter}"
-        flattened_registries = tuple(
-            chain(
-                *[
-                    [r["namespace"], r["item"]]
-                    for r in map(
-                        lambda rpath: ubiquerg.parse_registry_path(rpath),
-                        registry_paths,
-                    )
-                ]
-            )
-        )
-        results = self.run_sql_fetchall(sql_q, *flattened_registries)
-
-        # extract out the project config dictionary from the query
-        return [peppy.Project(project_dict=p[1]) for p in results]
-
-    def get_all_projects(
-        self,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> List[peppy.Project]:
-        """
-        Get a list of projects as peppy.Project instances.
-        Get all projects in the database (call empty)
-        :param limit: The maximum number of items to return.
-        :param offset: The index of the first item to return. Default: 0 (the first item).
-            Use with limit to get the next set of items.
-        :return: a list of peppy.Project instances for the requested projects.
-        """
-        offset_number = limit * offset
-        sql_q = f"select {PROJ_COL} from {DB_TABLE_NAME} limit {limit} offset {offset_number}"
-        result = self.run_sql_fetchall(sql_q)
-        proj_list = []
-
-        for raw_proj in result:
-            try:
-                proj_list.append(peppy.Project().from_dict(raw_proj[0]))
-            except Exception as err:
-                _LOGGER.error(f"Exception in {err}")
-        return proj_list
-
     def get_namespace_info(self, namespace: str) -> dict:
         """
         Fetch a particular namespace from the database. This doesn't retrieve full project
@@ -449,7 +384,7 @@ class Connection:
         """
         try:
             sql_q = f"select {ID_COL}, {NAME_COL}, {TAG_COL}, {DIGEST_COL}, {ANNO_COL} from {DB_TABLE_NAME} where {NAMESPACE_COL} = %s"
-            results = self.run_sql_fetchall(sql_q, namespace)
+            results = self._run_sql_fetchall(sql_q, namespace)
             projects = [
                 {
                     "id": p[0],
@@ -494,7 +429,7 @@ class Connection:
                 )
         else:
             sql_q = f"""SELECT DISTINCT {NAMESPACE_COL} FROM {DB_TABLE_NAME};"""
-            namespaces = [n[0] for n in self.run_sql_fetchall(sql_q)]
+            namespaces = [n[0] for n in self._run_sql_fetchall(sql_q)]
             if names_only:
                 return [n for n in namespaces]
 
@@ -537,7 +472,7 @@ class Connection:
 
         if name:
             sql_q = f""" {sql_q} where {NAME_COL}=%s and {NAMESPACE_COL}=%s and {TAG_COL}=%s;"""
-            found_prj = self.run_sql_fetchone(sql_q, name, namespace, tag)
+            found_prj = self._run_sql_fetchone(sql_q, name, namespace, tag)
 
         else:
             _LOGGER.error(
@@ -578,65 +513,6 @@ class Connection:
 
         return self.get_project_annotation(namespace=namespace, name=name, tag=tag)
 
-    def get_projects_annotation_by_namespace(self, namespace: str) -> dict:
-        """
-        Get list of all project annotations in namespace
-        :param namespace: namespace
-        return: dict of dicts with all projects in namespace
-        """
-
-        if not namespace:
-            _LOGGER.info(f"No namespace provided... returning empty list")
-            return {}
-
-        sql_q = f"""select 
-                    {NAME_COL},
-                    {NAMESPACE_COL},
-                    {TAG_COL},
-                    {ANNO_COL}
-                        from {DB_TABLE_NAME} where {NAMESPACE_COL}=%s;"""
-
-        results = self.run_sql_fetchall(sql_q, namespace)
-        res_dict = {}
-        for result in results:
-            dict_key = f"{result[1]}/{result[0]}:{result[2]}"
-            res_dict[dict_key] = Annotation(
-                registry=dict_key, annotation_dict=result[3]
-            )
-
-        return res_dict
-
-    def get_projects_annotation_by_namespace_tag(
-        self, namespace: str, tag: str
-    ) -> dict:
-        """
-        Get list of all project annotations in namespace
-        :param tag: tag of the project
-        :param namespace: namespace
-        return: dict of dicts with all projects in namespace
-        """
-
-        if not namespace:
-            _LOGGER.info(f"No namespace provided... returning empty list")
-            return {}
-
-        sql_q = f"""select 
-                    {NAME_COL},
-                    {NAMESPACE_COL},
-                    {TAG_COL},
-                    {ANNO_COL}
-                        from {DB_TABLE_NAME} where namespace=%s and tag=%s;"""
-
-        results = self.run_sql_fetchall(sql_q, namespace, tag)
-        res_dict = {}
-        for result in results:
-            dict_key = f"{result[1]}/{result[0]}:{result[2]}"
-            res_dict[dict_key] = Annotation(
-                registry=dict_key, annotation_dict=result[3]
-            )
-
-        return res_dict
-
     def get_namespace_annotation(self, namespace: str = None) -> dict:
         """
         Retrieving namespace annotation dict.
@@ -652,7 +528,7 @@ class Connection:
             from {DB_TABLE_NAME}
                 group by {NAMESPACE_COL};
         """
-        result = self.run_sql_fetchall(sql_q)
+        result = self._run_sql_fetchall(sql_q)
         anno_dict = {}
 
         for name_sp_result in result:
@@ -705,7 +581,7 @@ class Connection:
                           {NAME_COL} = %s AND 
                           {TAG_COL} = %s;"""
 
-        if self.run_sql_fetchone(sql, namespace, name, tag):
+        if self._run_sql_fetchone(sql, namespace, name, tag):
             return True
         else:
             return False
@@ -737,85 +613,7 @@ class Connection:
         else:
             return False
 
-    def project_status(
-        self,
-        namespace: str = None,
-        name: str = None,
-        tag: str = None,
-    ) -> Union[str, None]:
-        """
-        Retrieve project status by providing name, namespace and tag
-        :param namespace: project registry - will return dict of project annotations
-        :param name: project name in database. [required if registry_path does not specify]
-        :param tag: tag of the projects
-        :return: status
-        """
-        sql_q = f"""
-                select ({ANNO_COL}->>'{STATUS_KEY}') as status
-                        from {DB_TABLE_NAME}
-                            WHERE {NAMESPACE_COL}=%s AND
-                                {NAME_COL}=%s AND {TAG_COL}=%s;
-                """
-        if namespace is None:
-            namespace = DEFAULT_NAMESPACE
-        if tag is None:
-            tag = DEFAULT_TAG
-
-        if not name:
-            _LOGGER.error(
-                "You haven't provided neither registry_path or name! Execution is unsuccessful. "
-                "Files haven't been downloaded, returning empty dict"
-            )
-            return "None"
-
-        if not self.project_exists(namespace=namespace, name=name, tag=tag):
-            _LOGGER.error("Project does not exist, returning None")
-            return "None"
-
-        try:
-            result = self.run_sql_fetchone(sql_q, namespace, name, tag)[0]
-        except IndexError:
-            return "Unknown"
-        return result
-
-    def project_status_by_registry(
-        self,
-        registry_path: str = None,
-    ) -> str:
-        """
-        Retrieve project status by providing registry path
-        :param registry_path: project registry
-
-        :return: status
-        """
-        reg = ubiquerg.parse_registry_path(registry_path)
-        namespace = reg["namespace"]
-        name = reg["item"]
-        tag = reg["tag"]
-
-        if namespace is None:
-            namespace = DEFAULT_NAMESPACE
-        if tag is None:
-            tag = DEFAULT_TAG
-
-        return self.project_status(namespace=namespace, name=name, tag=tag)
-
-    def get_registry_paths_by_digest(self, digest: str):
-        """
-        Get project registry by digest
-        :param digest: Digest of the project
-        """
-        sql_q = f"select {NAMESPACE_COL}, {NAME_COL}, {TAG_COL} from {DB_TABLE_NAME} where {DIGEST_COL} = %s"
-        results = self.run_sql_fetchall(sql_q, digest)
-
-        registry_list = []
-
-        for res in results:
-            registry_list.append(f"{res[0]}/{res[1]}:{res[2]}")
-
-        return registry_list
-
-    def run_sql_fetchone(self, sql_query: str, *argv) -> list:
+    def _run_sql_fetchone(self, sql_query: str, *argv) -> list:
         """
         Fetching one result by providing sql query and arguments
         :param sql_query: sql string that has to run
@@ -837,7 +635,7 @@ class Connection:
         finally:
             cursor.close()
 
-    def run_sql_fetchall(self, sql_query: str, *argv) -> list:
+    def _run_sql_fetchall(self, sql_query: str, *argv) -> list:
         """
         Fetching all result by providing sql query and arguments
         :param str sql_query: sql string that has to run
@@ -880,7 +678,7 @@ class Connection:
             FROM INFORMATION_SCHEMA.COLUMNS
             WHERE TABLE_NAME = N'{DB_TABLE_NAME}'
             """
-        result = self.run_sql_fetchall(a)
+        result = self._run_sql_fetchall(a)
         cols_name = []
         for col in result:
             cols_name.append(col[3])

--- a/pepdbagent/pepdbagent.py
+++ b/pepdbagent/pepdbagent.py
@@ -261,7 +261,9 @@ class Connection:
         else:
             _LOGGER.error("Project does not exist! No project will be updated!")
 
-    def get_project_by_registry(self, registry_path: str = None) -> Union[peppy.Project, None]:
+    def get_project_by_registry(
+        self, registry_path: str = None
+    ) -> Union[peppy.Project, None]:
         """
         Retrieving project from database by specifying project registry_path
         :param registry_path: project registry_path [e.g. namespace/name:tag]

--- a/tests/test_pepagent.py
+++ b/tests/test_pepagent.py
@@ -29,7 +29,7 @@ class TestDatafetching:
 
     @pytest.mark.parametrize("registry", EXAMPLE_REGISTRIES)
     def test_get_project_by_registry(self, registry):
-        project = self.db.get_project_by_registry(registry)
+        project = self.db.get_project_by_registry_path(registry)
         assert isinstance(project, peppy.Project)
 
     def test_get_projects_by_list(self):
@@ -58,5 +58,5 @@ class TestDatafetching:
     def test_nonexistent_project(self):
         this_registry_doesnt_exist = "blueberry/pancakes"
         with pytest.warns():
-            proj = self.db.get_project_by_registry(this_registry_doesnt_exist)
+            proj = self.db.get_project_by_registry_path(this_registry_doesnt_exist)
             assert proj is None


### PR DESCRIPTION
In this PR, I deleted methods that are not used in pephub.
In my oppinion, some of this methods are usefull and and were written by @nleroy917 request.


--
Could you please check if this fuctions can be deleted, and won't be used?

I haven't deleted `get_project_annotation` method, as this is one way to retrieve annotation from project annotation column.