### PR TITLE
Add namespace-scoped performance indexes on projects

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 
+## [Unreleased]
+- Added namespace-oriented performance indexes on `projects`: composite `(namespace, last_update_date)` for namespace project listings, a covering partial index `(namespace) INCLUDE (number_of_samples, name) WHERE private IS FALSE` for namespace aggregation, and a trigram GIN index on `namespace` for `ILIKE` search
+
 ## [0.13.0] -- 2026-07-01
 - Migrated from `peppy` to `peprs` across all modules (project, sample, view, models, utils)
 - Updated subsample key constant: `SUBSAMPLE_RAW_LIST_KEY` → `SUBSAMPLE_RAW_DICT_KEY`

--- a/pepdbagent/db_utils.py
+++ b/pepdbagent/db_utils.py
@@ -166,6 +166,30 @@ class Projects(Base):
         Index("ix_projects_last_update_date", "last_update_date"),
         Index("ix_projects_submission_date", "submission_date"),
         Index("ix_projects_number_of_stars", "number_of_stars"),
+        # Composite for namespace project listings
+        # (WHERE namespace = ? ORDER BY last_update_date DESC LIMIT n): a bounded
+        # index range scan instead of walking the global last_update_date index
+        # and filtering by namespace (the plan flip that scans most of the table
+        # for a namespace whose rows are not near the date tip), and no full sort.
+        Index("ix_projects_namespace_update_date", "namespace", "last_update_date"),
+        # Covering partial index for namespace aggregation
+        # (SELECT namespace, count(name), sum(number_of_samples) GROUP BY namespace):
+        # an index-only scan (~25 MB) instead of a ~250 MB heap seq scan. Covers
+        # only the public rows aggregated and INCLUDEs the summed/counted columns.
+        # (Needs a fresh visibility map — run VACUUM ANALYZE projects afterward.)
+        Index(
+            "ix_projects_ns_agg",
+            "namespace",
+            postgresql_include=["number_of_samples", "name"],
+            postgresql_where=text("private IS FALSE"),
+        ),
+        # Trigram GIN on namespace for namespace ILIKE '%str%' search.
+        Index(
+            "trgm_index_namespace",
+            "namespace",
+            postgresql_using="gin",
+            postgresql_ops={"namespace": "gin_trgm_ops"},
+        ),
     )
 
 


### PR DESCRIPTION
Builds on `query_improvements`. Adds the indexes for the two **namespace-scoped** hot paths, complementing this branch's search / ORDER-BY indexes and N+1 fix. Added as model-level `Index()` to match the convention here.

## Indexes added (`Projects.__table_args__`)

| Index | Purpose |
|---|---|
| `ix_projects_namespace_update_date` on `(namespace, last_update_date)` | Namespace project listing (`WHERE namespace = ? ORDER BY last_update_date DESC LIMIT n`) → bounded index range scan instead of walking the global `last_update_date` index and filtering by namespace (the plan flip that scans most of the table for a namespace whose rows are not near the date tip), and no full sort. |
| `ix_projects_ns_agg` on `(namespace) INCLUDE (number_of_samples, name) WHERE private IS FALSE` | Namespace aggregation (`SELECT namespace, count(name), sum(number_of_samples) ... GROUP BY namespace`) → index-only scan (~25 MB) instead of a ~250 MB heap seq scan. Needs a fresh visibility map, so run `VACUUM ANALYZE projects` after. |
| `trgm_index_namespace` GIN on `namespace` | Namespace `ILIKE` search. |

## Why

The two namespace paths were full-scanning the ~250 MB `projects` heap on every request. On a RAM-starved host that means seconds-to-minutes of cold reads. These make both paths read a bounded, cacheable number of pages.

## Applying to production (existing DB)

`create_all` (checkfirst) covers fresh installs. For the existing prod table, create concurrently so no blocking lock, then vacuum for the index-only scan:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_projects_namespace_update_date
    ON projects (namespace, last_update_date);
CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_projects_ns_agg
    ON projects (namespace) INCLUDE (number_of_samples, name) WHERE private IS FALSE;
CREATE INDEX CONCURRENTLY IF NOT EXISTS trgm_index_namespace
    ON projects USING gin (namespace gin_trgm_ops);
VACUUM ANALYZE projects;
```

Recommended cleanup while applying (not expressible via `create_all`), to cut write amplification:

```sql
DROP INDEX CONCURRENTLY IF EXISTS registry_index;              -- exact dup of projects_namespace_name_tag_key
DROP INDEX CONCURRENTLY IF EXISTS project_id_samp_index_ccnew; -- leftover invalid index from an interrupted REINDEX
```

## Notes

- The new `Index()` DDL was verified to compile cleanly against the PostgreSQL dialect.
- Index changes alone are mitigation; they do not cure the underlying host RAM/EBS-bandwidth constraint (tracked separately).