### PR TITLE
Remove import-time logging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,16 @@ to increase readability, maintainability, and user experience of pepdbagent, whi
 
 ```python
 import pepdbagent
+
 # 1) By providing credentials and connection information:
-agent = pepdbagent.PEPDatabaseAgent(user="postgres", password="docker", )
+agent = pepdbagent.PEPDatabaseAgent(
+    user="postgres",
+    password="docker",
+)
 # 2) or By providing connection string:
-agent = pepdbagent.PEPDatabaseAgent(dsn="postgresql://postgres:docker@localhost:5432/pep-db")
+agent = pepdbagent.PEPDatabaseAgent(
+    dsn="postgresql://postgres:docker@localhost:5432/pep-db"
+)
 ```
 
 #### Example of usage of the pepdbagent modules:
@@ -125,13 +131,13 @@ Example:
 ```python
 # Get info about namespace by providing query argument. Then pepdbagent will
 # search for a specified pattern of namespace in database.
-agent.namespace.get(query='Namespace')
+agent.namespace.get(query="Namespace")
 
 # By default all get functions will return namespace information for public projects,
 # To get information with private projects, admin list should be provided.
 # admin list means list of namespaces where user has admin rights
 # For example:
-agent.namespace.get(query='search_pattern', admin=['databio', 'geo', 'ncbi'])
+agent.namespace.get(query="search_pattern", admin=["databio", "geo", "ncbi"])
 ```
 For more information, developers should use `pepdbagent pytest` as documentation due to its natural language syntax and the 
 ability to write tests that serve as executable examples. 
@@ -168,6 +174,7 @@ in creation of the PEPDBAgent object. For example:
 
 ```python
 from pepdbagent import PEPDBAgent
+
 pdb = PEPDatabaseAgent(
     user="postgres",
     password="pass8743hf9h23f87h437",

--- a/pepdbagent/__init__.py
+++ b/pepdbagent/__init__.py
@@ -2,18 +2,8 @@
 
 from importlib.metadata import version
 
-import coloredlogs
-import logmuse
-
 from pepdbagent.pepdbagent import PEPDatabaseAgent
 
 __version__ = version("pepdbagent")
 
 __all__ = ["__version__", "PEPDatabaseAgent"]
-
-_LOGGER = logmuse.init_logger("pepdbagent")
-coloredlogs.install(
-    logger=_LOGGER,
-    datefmt="%H:%M:%S",
-    fmt="[%(levelname)s] [%(asctime)s] %(message)s",
-)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,8 @@ classifiers = [
 ]
 dependencies = [
     "sqlalchemy>=2.0.0",
-    "logmuse>=0.2.7",
     "peprs>=0.2.1",
     "ubiquerg>=0.6.2",
-    "coloredlogs>=15.0.1",
     "pydantic>=2.0",
     "psycopg>=3.1.15",
     "numpy>=1.24.4",


### PR DESCRIPTION
pepdbagent used to configure logging as a side effect of being imported. `__init__.py` called `logmuse.init_logger("pepdbagent")` and then `coloredlogs.install()`, so simply running `import pepdbagent` would attach a handler and start coloring output.

That is the wrong place for that decision. pepdbagent is a library with no command line of its own, so the application using it should decide how its logs look.

Worse, `init_logger` sets `propagate = False` on the logger. That disconnects pepdbagent from the normal logging chain, so an application that configures logging the usual way gets nothing from pepdbagent at all. The only way around it is to reach in and configure the `pepdbagent` logger by name.

That is exactly what pephub does today, in `pephub/main.py`, where it sets its own level and `[PEPDBAGENT]` prefix. That still works after this change, so nothing needs to be updated in pephub. It just no longer has to fight the defaults.

This PR deletes the setup block from `__init__.py` and drops `logmuse` and `coloredlogs` from the dependencies, since nothing else in the package used either one. Every module already gets its logger with `logging.getLogger(PKG_NAME)`, and nothing imported `_LOGGER` from the package root, so there is nothing else to change.

This follows the guidance added in logmuse 0.3.0, which now also applies colors on its own when coloredlogs is installed. Similar cleanups are needed in geopephub, bedboss, bedhost, and pephubclient.